### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ your device, please contact to developer.
   * Tascam FW-1804
   * Tascam FE-8
 
-* snd-fireowrks-ctl-service
+* snd-fireworks-ctl-service
 
   * Mackie (Loud) Onyx 1200F
   * Mackie (Loud) Onyx 400F


### PR DESCRIPTION
Typo in fireworks word.